### PR TITLE
Add travis CI for Linux and OSX testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,70 @@
+---
+sudo: false
+language: c++
+# dotnet cli require Ubuntu 14.04
+sudo: required
+dist: trusty
+
+# dotnet cli require OSX 10.10
+osx_image: xcode7.1
+
+addons:
+  apt:
+    packages:
+    - gettext
+    - libcurl4-openssl-dev
+    - libicu-dev
+    - libssl-dev
+    - libunwind8
+    - zlib1g
+
+os:
+  - osx
+  - linux
+
+env:
+  matrix:
+    - CLI_VERSION: Latest
+      Configuration: Debug
+    - CLI_VERSION: Latest
+      Configuration: Release
+
+before_install:
+  # Install OpenSSL
+  - if test "$TRAVIS_OS_NAME" == "osx"; then
+      brew update;
+      brew install openssl;
+      brew link --force openssl;
+    fi
+
+  # Download script to install dotnet cli
+  - curl -L --create-dirs https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh -o ./scripts/install.sh
+
+  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
+
+  # Install the latest versio of dotnet CLI
+  - bash ./scripts/install.sh --channel "beta" --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR" --no-path
+
+  # Add dotnet to PATH
+  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
+
+install:
+  # Display dotnet version info
+  - which dotnet;
+    if [ $? -eq 0 ]; then
+      echo "Using dotnet:";
+      dotnet --info;
+    else
+      echo "dotnet.exe not found"
+      exit 1;
+    fi
+
+  # Restore dependencies
+  - dotnet restore
+
+  # Build projects
+  - dotnet build -c $Configuration -f netcoreapp1.0 ./test/dotnet-test-nunit.test.runner
+
+script:
+  # Run tests
+  - dotnet run -c $Configuration -f netcoreapp1.0 -p ./test/dotnet-test-nunit.test.runner

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NUnit 3 Test Runner for .NET Core
 
-[![Build status](https://ci.appveyor.com/api/projects/status/yg7dawcy1106g1li/branch/master?svg=true)](https://ci.appveyor.com/project/CharliePoole/dotnet-test-nunit/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/yg7dawcy1106g1li/branch/master?svg=true)](https://ci.appveyor.com/project/CharliePoole/dotnet-test-nunit/branch/master) [![Travis Build Status](https://travis-ci.org/nunit/dotnet-test-nunit.svg?branch=master)](https://travis-ci.org/nunit/dotnet-test-nunit)
 
 `dotnet-test-nunit` is the unit test runner for .NET Core for running unit tests with NUnit 3.
 


### PR DESCRIPTION
This is to validate #9.

@rprouse this will pass once `imports` array in project.json is gone.