### PR TITLE
Command line options

### DIFF
--- a/src/dotnet-test-nunit/CommandLineOptions.cs
+++ b/src/dotnet-test-nunit/CommandLineOptions.cs
@@ -105,14 +105,6 @@ namespace NUnit.Runner
 
         public bool NoColor { get; private set; }
 
-        public bool Verbose { get; private set; }
-
-        public string OutFile { get; private set; }
-        public bool OutFileSpecified => OutFile != null;
-
-        public string ErrFile { get; private set; }
-        public bool ErrFileSpecified => ErrFile != null;
-
         public string DisplayTestLabels { get; private set; }
 
         string workDirectory = null;
@@ -122,9 +114,6 @@ namespace NUnit.Runner
 
         public string InternalTraceLevel { get; private set; }
         public bool InternalTraceLevelSpecified => InternalTraceLevel != null;
-
-        /// <summary>Indicates whether a full report should be displayed.</summary>
-        public bool Full { get; private set; }
 
         private List<OutputSpecification> resultOutputSpecifications = new List<OutputSpecification>();
         public IList<OutputSpecification> ResultOutputSpecifications
@@ -276,15 +265,6 @@ namespace NUnit.Runner
             this.Add("work=", "{PATH} of the directory to use for output files. If not specified, defaults to the current directory.",
                 v => workDirectory = RequiredValue(v, "--work"));
 
-            this.Add("output|out=", "File {PATH} to contain text output from the tests.",
-                v => OutFile = RequiredValue(v, "--output"));
-
-            this.Add("err=", "File {PATH} to contain error output from the tests.",
-                v => ErrFile = RequiredValue(v, "--err"));
-
-            this.Add("full", "Prints full report of all test results.",
-                v => Full = v != null);
-
             this.Add("result=", "An output {SPEC} for saving the test results.\nThis option may be repeated.",
                 v => resultOutputSpecifications.Add(new OutputSpecification(RequiredValue(v, "--resultxml"))));
 
@@ -313,10 +293,7 @@ namespace NUnit.Runner
             this.Add("nocolor|noc", "Displays console output without color.",
                 v => NoColor = v != null);
 
-            this.Add("verbose|v", "Display additional information as the test runs.",
-                v => Verbose = v != null);
-
-            this.Add("help|h", "Display this message and exit.",
+            this.Add("help|h|?", "Display this message and exit.",
                 v => ShowHelp = v != null);
 
             this.Add("version|V", "Display the header and exit.",

--- a/src/dotnet-test-nunit/TestListeners/TestExecutionListener.cs
+++ b/src/dotnet-test-nunit/TestListeners/TestExecutionListener.cs
@@ -45,6 +45,7 @@ namespace NUnit.Runner.TestListeners
             switch (element?.Name?.LocalName)
             {
                 case "start-suite":
+                    break;
                 case "test-suite":
                     break;
                 case "start-test":

--- a/src/dotnet-test-nunit/TestRunner.cs
+++ b/src/dotnet-test-nunit/TestRunner.cs
@@ -189,6 +189,11 @@ namespace NUnit.Runner
                 }
                 else
                 {
+
+                    var labels = _options.DisplayTestLabels != null
+                         ? _options.DisplayTestLabels.ToUpperInvariant()
+                         : "ON";
+
                     ITestListener listener = new TestExecutionListener(_testExecutionSink, _options, assemblyPath);
                     string xml = driver.Run(listener.OnTestEvent, filter.Text);
                     summary.AddResult(xml);
@@ -227,6 +232,17 @@ namespace NUnit.Runner
 
             // Return the number of test failures
             return summary.FailedCount;
+        }
+
+        private string _currentLabel;
+
+        private void WriteLabelLine(string label)
+        {
+            if (label != _currentLabel)
+            {
+                ColorConsole.WriteLine(ColorStyle.SectionHeader, $"=> {label}");
+                _currentLabel = label;
+            }
         }
 
         public void Dispose()

--- a/src/dotnet-test-nunit/TestRunner.cs
+++ b/src/dotnet-test-nunit/TestRunner.cs
@@ -24,8 +24,6 @@
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.Extensions.Testing.Abstractions;
 using Newtonsoft.Json;
-using NUnit.Common;
-using NUnit.Compatibility;
 using NUnit.Engine;
 using NUnit.Options;
 using NUnit.Runner.Interfaces;
@@ -182,7 +180,7 @@ namespace NUnit.Runner
 
                 // TODO: Run async
                 // Explore or Run
-                if (_options.List)
+                if (_options.List || _options.Explore)
                 {
                     ITestListener listener = new TestExploreListener(_testDiscoverySink, _options, assemblyPath);
                     string xml = driver.Explore(filter.Text);
@@ -197,7 +195,7 @@ namespace NUnit.Runner
                 }
             }
 
-            if (_options.List)
+            if (_options.List || _options.Explore)
             {
                 if (_options.DesignTime)
                     _testDiscoverySink.SendTestCompleted();
@@ -253,36 +251,42 @@ namespace NUnit.Runner
             IDictionary<string, object> settings = new Dictionary<string, object>();
 
             if (_options.DefaultTimeout >= 0)
-                settings.Add(PackageSettings.DefaultTimeout, _options.DefaultTimeout);
+                settings.Add(FrameworkSettings.DefaultTimeout, _options.DefaultTimeout);
 
             if (_options.InternalTraceLevelSpecified)
-                settings.Add(PackageSettings.InternalTraceLevel, _options.InternalTraceLevel);
+                settings.Add(FrameworkSettings.InternalTraceLevel, _options.InternalTraceLevel);
 
             // Always add work directory, in case current directory is changed
             var workDirectory = _options.WorkDirectory ?? Directory.GetCurrentDirectory();
-            settings.Add(PackageSettings.WorkDirectory, workDirectory);
+            settings.Add(FrameworkSettings.WorkDirectory, workDirectory);
 
             if (_options.StopOnError)
-                settings.Add(PackageSettings.StopOnError, true);
+                settings.Add(FrameworkSettings.StopOnError, true);
 
 #if false
             if (options.NumberOfTestWorkersSpecified)
-                package.Add(PackageSettings.NumberOfTestWorkers, options.NumberOfTestWorkers);
+                package.Add(FrameworkSettings.NumberOfTestWorkers, options.NumberOfTestWorkers);
 #endif
 
             if (_options.RandomSeedSpecified)
-                settings.Add(PackageSettings.RandomSeed, _options.RandomSeed);
+                settings.Add(FrameworkSettings.RandomSeed, _options.RandomSeed);
 
 #if NET451
             if (_options.Debug)
             {
-                settings.Add(PackageSettings.DebugTests, true);
+                settings.Add(FrameworkSettings.DebugTests, true);
 #if false
                 if (!options.NumberOfTestWorkersSpecified)
-                    package.Add(PackageSettings.NumberOfTestWorkers, 0);
+                    package.Add(FrameworkSettings.NumberOfTestWorkers, 0);
 #endif
             }
 #endif
+
+            if (_options.DefaultTestNamePattern != null)
+                settings.Add(FrameworkSettings.DefaultTestNamePattern, _options.DefaultTestNamePattern);
+
+            if (_options.TestParameters != null)
+                settings.Add(FrameworkSettings.TestParameters, _options.TestParameters);
 
             return settings;
         }

--- a/src/dotnet-test-nunit/project.json
+++ b/src/dotnet-test-nunit/project.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview2-003121",
     "Microsoft.Extensions.DependencyModel": "1.0.0",
-    "NUnit.Portable.Agent": "3.4.0-beta-1"
+    "NUnit.Portable.Agent": "3.3.0.58-issue-10"
   },
 
   "frameworks": {

--- a/src/dotnet-test-nunit/project.json
+++ b/src/dotnet-test-nunit/project.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview2-003121",
     "Microsoft.Extensions.DependencyModel": "1.0.0",
-    "NUnit.Portable.Agent": "3.3.0.58-issue-10"
+    "NUnit.Portable.Agent": "3.3.0.60-CI"
   },
 
   "frameworks": {

--- a/test/dotnet-test-nunit.test/CommandLineOptionsTests.cs
+++ b/test/dotnet-test-nunit.test/CommandLineOptionsTests.cs
@@ -21,8 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+using System.IO;
 using System.Reflection;
-using NUnit.Common;
+using NUnit.Engine;
 using NUnit.Framework;
 using NUnit.Options;
 
@@ -159,6 +161,7 @@ namespace NUnit.Runner.Test
         [TestCase("--work")]
         [TestCase("--trace")]
         [TestCase("--port")]
+        [TestCase("--params")]
         public void MissingValuesAreReported(string option)
         {
             CommandLineOptions options = new CommandLineOptions(option + "=");
@@ -416,6 +419,64 @@ namespace NUnit.Runner.Test
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
             Assert.AreEqual("C:/nunit/tests/bin/Debug/console-test.xml", options.ExploreOutputSpecifications[0].OutputPath);
+        }
+
+        #endregion
+
+        #region Test Parameters
+
+        [Test]
+        public void SingleTestParameter()
+        {
+            var options = new CommandLineOptions("--params=X=5");
+            Assert.That(options.ErrorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo("X=5"));
+        }
+
+        [Test]
+        public void TwoTestParametersInOneOption()
+        {
+            var options = new CommandLineOptions("--params:X=5;Y=7");
+            Assert.That(options.ErrorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo("X=5;Y=7"));
+        }
+
+        [Test]
+        public void TwoTestParametersInSeparateOptions()
+        {
+            var options = new CommandLineOptions("-p:X=5", "-p:Y=7");
+            Assert.That(options.ErrorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo("X=5;Y=7"));
+        }
+
+        [Test]
+        public void ThreeTestParametersInTwoOptions()
+        {
+            var options = new CommandLineOptions("--params:X=5;Y=7", "-p:Z=3");
+            Assert.That(options.ErrorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo("X=5;Y=7;Z=3"));
+        }
+
+        [Test]
+        public void ParameterWithoutEqualSignIsInvalid()
+        {
+            var options = new CommandLineOptions("--params=X5");
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void DisplayTestParameters()
+        {
+            if (TestContext.Parameters.Count == 0)
+            {
+                Console.WriteLine("No Test Parameters were passed");
+                return;
+            }
+
+            Console.WriteLine("Test Parameters---");
+
+            foreach (var name in TestContext.Parameters.Names)
+                Console.WriteLine("   Name: {0} Value: {1}", name, TestContext.Parameters[name]);
         }
 
         #endregion

--- a/test/dotnet-test-nunit.test/CommandLineOptionsTests.cs
+++ b/test/dotnet-test-nunit.test/CommandLineOptionsTests.cs
@@ -88,8 +88,6 @@ namespace NUnit.Runner.Test
         }
 
         [TestCase("WhereClause", "where", new string[] { "cat==Fast" }, new string[0])]
-        [TestCase("OutFile", "output|out", new string[] { "output.txt" }, new string[0])]
-        [TestCase("ErrFile", "err", new string[] { "error.txt" }, new string[0])]
         [TestCase("WorkDirectory", "work", new string[] { "results" }, new string[0])]
         [TestCase("DisplayTestLabels", "labels", new string[] { "Off", "On", "All" }, new string[] { "JUNK" })]
         [TestCase("InternalTraceLevel", "trace", new string[] { "Off", "Error", "Warning", "Info", "Debug", "Verbose" }, new string[] { "JUNK" })]
@@ -156,8 +154,6 @@ namespace NUnit.Runner.Test
 
         [TestCase("--where")]
         [TestCase("--timeout")]
-        [TestCase("--output")]
-        [TestCase("--err")]
         [TestCase("--work")]
         [TestCase("--trace")]
         [TestCase("--port")]


### PR DESCRIPTION
Fixes #33 
Fixes #4 

- Adds all supported command line options and removes those that are not supported. See #4 for a complete list.
- Updated to use the latest CI version of NUnit.Portable.Agent with its fixes. Will need to update to a new release.
- Adds the new `--params` command line option
- Labels are now supported