### PR TITLE
Fix few issues with labels

### DIFF
--- a/src/dotnet-test-nunit/TestListeners/TestExecutionListener.cs
+++ b/src/dotnet-test-nunit/TestListeners/TestExecutionListener.cs
@@ -103,7 +103,14 @@ namespace NUnit.Runner.TestListeners
         void OnTestCase(XElement xml)
         {
             var testResult = ParseTestResult(xml);
-            var output = testResult.Messages.Count > 0 ? testResult.Messages[0] : null;
+
+            string output = null;
+
+            if (testResult.Messages.Count > 0)
+                output = testResult.Messages[0];
+            else if (testResult.Outcome != TestOutcome.None)
+                output = testResult.Outcome.ToString();
+            
 
             TestFinished?.Invoke(this, new TestEventArgs(testResult.Test.FullyQualifiedName, output));
 

--- a/src/dotnet-test-nunit/TestListeners/TestExecutionListener.cs
+++ b/src/dotnet-test-nunit/TestListeners/TestExecutionListener.cs
@@ -55,6 +55,7 @@ namespace NUnit.Runner.TestListeners
 
     public class TestExecutionListener : BaseTestListener
     {
+        public event EventHandler<TestEventArgs> TestStarted;
         public event EventHandler<TestEventArgs> TestFinished;
         public event EventHandler<TestEventArgs> SuiteFinished;
         public event EventHandler<TestOutputEventArgs> TestOutput;
@@ -96,7 +97,9 @@ namespace NUnit.Runner.TestListeners
         {
             var test = ParseTest(xml);
 
-            if(Options.DesignTime)
+            TestStarted?.Invoke(this, new TestEventArgs(test.FullyQualifiedName, null));
+
+            if (Options.DesignTime)
                 _sink?.SendTestStarted(test);
         }
 
@@ -109,8 +112,7 @@ namespace NUnit.Runner.TestListeners
             if (testResult.Messages.Count > 0)
                 output = testResult.Messages[0];
             else if (testResult.Outcome != TestOutcome.None)
-                output = testResult.Outcome.ToString();
-            
+                output = testResult.Outcome.ToString();            
 
             TestFinished?.Invoke(this, new TestEventArgs(testResult.Test.FullyQualifiedName, output));
 

--- a/src/dotnet-test-nunit/TestRunner.cs
+++ b/src/dotnet-test-nunit/TestRunner.cs
@@ -236,11 +236,14 @@ namespace NUnit.Runner
                  ? _options.DisplayTestLabels.ToUpperInvariant()
                  : "ON";
 
-            listener.TestFinished += (sender, args) =>
+            listener.TestStarted += (sender, args) =>
             {
                 if (labels == "ALL")
                     WriteLabelLine(args.TestName);
+            };
 
+            listener.TestFinished += (sender, args) =>
+            {                
                 if (args.TestOutput != null)
                 {
                     if (labels == "ON")

--- a/test/dotnet-test-nunit.test/TestListeners/TestExecutionListenerTests.cs
+++ b/test/dotnet-test-nunit.test/TestListeners/TestExecutionListenerTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using Microsoft.Extensions.Testing.Abstractions;
 using NUnit.Framework;
 using NUnit.Runner.TestListeners;
@@ -108,7 +109,12 @@ namespace NUnit.Runner.Test.TestListeners
         [Test]
         public void CanParseSuccess()
         {
+            var eventHandler =
+                new EventHandler<TestEventArgs>((sender, args) => Assert.That(args.TestOutput, Is.EqualTo("Passed")));
+            _listener.TestFinished += eventHandler;
+
             _listener.OnTestEvent(SUCCESS_TEST_CASE_XML);
+            
             var testResult = _sink.TestResult;
             Assert.That(testResult, Is.Not.Null);
             Assert.That(testResult.ErrorMessage, Is.Null.Or.Empty);
@@ -117,11 +123,17 @@ namespace NUnit.Runner.Test.TestListeners
             Assert.That(testResult.StartTime.Hour, Is.EqualTo(23));
             Assert.That(testResult.EndTime.Minute, Is.EqualTo(31));
             Assert.That(testResult.Duration.TotalSeconds, Is.EqualTo(0.000001d).Within(0.001d));
+
+            _listener.TestFinished -= eventHandler;
         }
 
         [Test]
         public void CanParseIgnoredTests()
         {
+            var eventHandler =
+                new EventHandler<TestEventArgs>((sender, args) => Assert.That(args.TestOutput, Is.EqualTo("Skipped")));
+            _listener.TestFinished += eventHandler;
+
             _listener.OnTestEvent(IGNORE_TEST_CASE_XML);
             var testResult = _sink.TestResult;
             Assert.That(testResult, Is.Not.Null);
@@ -131,11 +143,17 @@ namespace NUnit.Runner.Test.TestListeners
             Assert.That(testResult.StartTime.Hour, Is.EqualTo(23));
             Assert.That(testResult.EndTime.Minute, Is.EqualTo(45));
             Assert.That(testResult.Duration.TotalSeconds, Is.EqualTo(0.000001d).Within(0.001d));
+
+            _listener.TestFinished -= eventHandler;
         }
 
         [Test]
         public void CanParseExplicitTests()
         {
+            var eventHandler =
+                new EventHandler<TestEventArgs>((sender, args) => Assert.That(args.TestOutput, Is.EqualTo("Skipped")));
+            _listener.TestFinished += eventHandler;
+
             _listener.OnTestEvent(EXPLICIT_TEST_CASE_XML);
             var testResult = _sink.TestResult;
             Assert.That(testResult, Is.Not.Null);
@@ -145,11 +163,17 @@ namespace NUnit.Runner.Test.TestListeners
             Assert.That(testResult.StartTime.Hour, Is.EqualTo(23));
             Assert.That(testResult.EndTime.Minute, Is.EqualTo(45));
             Assert.That(testResult.Duration.TotalSeconds, Is.EqualTo(0.000001d).Within(0.001d));
+
+            _listener.TestFinished -= eventHandler;
         }
 
         [Test]
         public void CanParseTestErrors()
         {
+            var eventHandler =
+                new EventHandler<TestEventArgs>((sender, args) => Assert.That(args.TestOutput, Is.EqualTo("Failed")));
+            _listener.TestFinished += eventHandler;
+
             _listener.OnTestEvent(ERROR_TEST_CASE_XML);
             var testResult = _sink.TestResult;
             Assert.That(testResult, Is.Not.Null);
@@ -159,11 +183,17 @@ namespace NUnit.Runner.Test.TestListeners
             Assert.That(testResult.StartTime.Hour, Is.EqualTo(19));
             Assert.That(testResult.EndTime.Minute, Is.EqualTo(57));
             Assert.That(testResult.Duration.TotalSeconds, Is.EqualTo(0.023031).Within(0.001d));
+
+            _listener.TestFinished -= eventHandler;
         }
 
         [Test]
         public void CanParseTestFailures()
         {
+            var eventHandler =
+                new EventHandler<TestEventArgs>((sender, args) => Assert.That(args.TestOutput, Is.EqualTo("Failed")));
+            _listener.TestFinished += eventHandler;
+
             _listener.OnTestEvent(FAILED_TEST_CASE_XML);
             var testResult = _sink.TestResult;
             Assert.That(testResult, Is.Not.Null);
@@ -173,6 +203,8 @@ namespace NUnit.Runner.Test.TestListeners
             Assert.That(testResult.StartTime.Hour, Is.EqualTo(19));
             Assert.That(testResult.EndTime.Minute, Is.EqualTo(57));
             Assert.That(testResult.Duration.TotalSeconds, Is.EqualTo(0.017533).Within(0.001d));
+
+            _listener.TestFinished -= eventHandler;
         }
 
         [Test]

--- a/test/dotnet-test-nunit.test/TestListeners/TestExecutionListenerTests.cs
+++ b/test/dotnet-test-nunit.test/TestListeners/TestExecutionListenerTests.cs
@@ -31,6 +31,9 @@ namespace NUnit.Runner.Test.TestListeners
     [TestFixture]
     public class TestExecutionListenerTests
     {
+        const string STARTED_TEST_CASE_XML =
+            "<start-test id=\"1006\" name=\"CanSubtract(-1,-1,0)\" fullname=\"NUnitWithDotNetCoreRC2.Test.CalculatorTests.CanSubtract(-1,-1,0)\" methodname=\"CanSubtract\" classname=\"NUnitWithDotNetCoreRC2.Test.CalculatorTests\" runstate=\"Runnable\" seed=\"1663476057\" start-time=\"2016-06-06 23:31:34Z\" />";
+
         const string SUCCESS_TEST_CASE_XML =
             "<test-case id=\"1006\" name=\"CanSubtract(-1,-1,0)\" fullname=\"NUnitWithDotNetCoreRC2.Test.CalculatorTests.CanSubtract(-1,-1,0)\" methodname=\"CanSubtract\" classname=\"NUnitWithDotNetCoreRC2.Test.CalculatorTests\" runstate=\"Runnable\" seed=\"1663476057\" result=\"Passed\" start-time=\"2016-06-06 23:31:34Z\" end-time=\"2016-06-06 23:31:34Z\" duration=\"0.000001\" asserts=\"1\" />";
 
@@ -273,6 +276,22 @@ namespace NUnit.Runner.Test.TestListeners
 
             Assert.That(stream, Is.Not.Null);
             Assert.That(stream, Is.EqualTo("theStream"));
+        }
+
+        [Test]
+        public void TestStarted()
+        {            
+            bool raised = false;
+
+            var eventHandler =
+                new EventHandler<TestEventArgs>((sender, args) => raised = true);
+            _listener.TestStarted += eventHandler;
+
+            _listener.OnTestEvent(STARTED_TEST_CASE_XML);
+
+            Assert.That(raised, Is.True);
+
+            _listener.TestFinished -= eventHandler;
         }
     }
 }


### PR DESCRIPTION
1. Outcome of a test is never printed
2. Test is being printed when the test is finished, problematic when I want to find an hanging thread. To fix printing the name of the test when the test starts