### PR TITLE
Issue-26: Small units of time should default to 1 tick

### DIFF
--- a/src/dotnet-test-nunit/Extensions/TestExtensions.cs
+++ b/src/dotnet-test-nunit/Extensions/TestExtensions.cs
@@ -72,11 +72,14 @@ namespace NUnit.Runner.Extensions
         /// </summary>
         /// <param name="attribute"></param>
         /// <returns></returns>
-        public static TimeSpan ConvertToTimeSpan(this XAttribute attribute)
+        public static TimeSpan ConvertToTimeSpan(this XAttribute attribute, TestOutcome outcome)
         {
             double duration = MIN_DURATION; // Some runners cannot handle a duration of 0
 
-            if(attribute != null)
+            if (outcome == TestOutcome.Skipped)
+                return TimeSpan.FromTicks(1);
+
+            if (attribute != null)
                 double.TryParse(attribute.Value, out duration);
 
             return TimeSpan.FromSeconds(Math.Max(duration, MIN_DURATION));

--- a/src/dotnet-test-nunit/TestListeners/TestExecutionListener.cs
+++ b/src/dotnet-test-nunit/TestListeners/TestExecutionListener.cs
@@ -139,12 +139,14 @@ namespace NUnit.Runner.TestListeners
         protected TestResult ParseTestResult(XElement xml)
         {
             var test = ParseTest(xml);
+            var outcomeAttr = xml.Attribute("result").ConvertToTestOutcome();
+
             var testResult = new TestResult(test)
             {
                 StartTime = xml.Attribute("start-time").ConvertToDateTime(),
                 EndTime = xml.Attribute("end-time").ConvertToDateTime(),
-                Duration = xml.Attribute("duration").ConvertToTimeSpan(),
-                Outcome = xml.Attribute("result").ConvertToTestOutcome(),
+                Outcome = outcomeAttr,
+                Duration = xml.Attribute("duration").ConvertToTimeSpan(outcomeAttr),
                 ComputerName = Environment.MachineName
             };
             // Output, Messages and stack traces

--- a/test/dotnet-test-nunit.test/Extensions/TestExtensionsTests.cs
+++ b/test/dotnet-test-nunit.test/Extensions/TestExtensionsTests.cs
@@ -95,7 +95,7 @@ namespace NUnit.Runner.Test.Extensions
         public void IgnoredTestsHaveDurationOf1Tick(string duration, double expected)
         {
             var durationAttr = new XAttribute("duration", duration);
-            var outcomeAttr = TestOutcome.Failed;
+            var outcomeAttr = TestOutcome.Skipped;
 
             var ts = durationAttr.ConvertToTimeSpan(outcomeAttr);
             Assert.That(ts.TotalSeconds, Is.EqualTo(expected).Within(0.001d));

--- a/test/dotnet-test-nunit.test/Extensions/TestExtensionsTests.cs
+++ b/test/dotnet-test-nunit.test/Extensions/TestExtensionsTests.cs
@@ -83,8 +83,21 @@ namespace NUnit.Runner.Test.Extensions
         [TestCase("", 0.001d, Description = "Default TimeSpan of 1 ms")]
         public void CanConvertDurations(string duration, double expected)
         {
-            var attr = new XAttribute("duration", duration);
-            var ts = attr.ConvertToTimeSpan();
+            var durationAttr = new XAttribute("duration", duration);
+            var outcomeAttr = TestOutcome.Passed;
+
+            var ts = durationAttr.ConvertToTimeSpan(outcomeAttr);
+            Assert.That(ts.TotalSeconds, Is.EqualTo(expected).Within(0.001d));
+        }
+
+        [TestCase("1", 0.0000001d)]
+        [TestCase("", 0.0000001d)]
+        public void IgnoredTestsHaveDurationOf1Tick(string duration, double expected)
+        {
+            var durationAttr = new XAttribute("duration", duration);
+            var outcomeAttr = TestOutcome.Failed;
+
+            var ts = durationAttr.ConvertToTimeSpan(outcomeAttr);
             Assert.That(ts.TotalSeconds, Is.EqualTo(expected).Within(0.001d));
         }
 


### PR DESCRIPTION
What about any value lower than 1ms?
Waiting until I can run tests, but meanwhile let's chat about this

Fixes #26