### PR TITLE
Fix for Issue #58, #76, and #80

### DIFF
--- a/src/dotnet-test-nunit/Extensions/TestExtensions.cs
+++ b/src/dotnet-test-nunit/Extensions/TestExtensions.cs
@@ -42,11 +42,20 @@ namespace NUnit.Runner.Extensions
         static SHA1 SHA { get; } = SHA1.Create();
 
         /// <summary>
-        /// Takes an NUnit fullname attribute and converts it to a Guid Id
+        /// Takes a string, signs it with a SHA1 algorithm and converts the 
+        /// resulting hash to a <see cref="Guid"/> 
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The SHA1 hash algorithm results in a 140 bit digest, but a 
+        /// Guid only stores 128 bits.  Therefore, we are tossing out
+        /// the last 12 bits of the SHA1 hash in order to convert the
+        /// result to a Guid.
+        /// </para>
+        /// </remarks>
         /// <param name="attribute"></param>
         /// <returns></returns>
-        public static Guid ConvertToGuid(this string attribute)
+        public static Guid GetSignatureAsGuid(this string attribute)
         {
             var hash = SHA.ComputeHash(Encoding.Unicode.GetBytes(attribute));
             var b = new byte[16];

--- a/src/dotnet-test-nunit/Extensions/TestExtensions.cs
+++ b/src/dotnet-test-nunit/Extensions/TestExtensions.cs
@@ -42,6 +42,19 @@ namespace NUnit.Runner.Extensions
         static SHA1 SHA { get; } = SHA1.Create();
 
         /// <summary>
+        /// Takes an NUnit fullname attribute and converts it to a Guid Id
+        /// </summary>
+        /// <param name="attribute"></param>
+        /// <returns></returns>
+        public static Guid ConvertToGuid(this string attribute)
+        {
+            var hash = SHA.ComputeHash(Encoding.Unicode.GetBytes(attribute));
+            var b = new byte[16];
+            Array.Copy(hash, b, 16);
+            return new Guid(b);
+        }
+
+        /// <summary>
         /// Takes an NUnit id attribute and converts it to a Guid Id
         /// </summary>
         /// <param name="attribute"></param>

--- a/src/dotnet-test-nunit/TestListeners/BaseTestListener.cs
+++ b/src/dotnet-test-nunit/TestListeners/BaseTestListener.cs
@@ -66,7 +66,7 @@ namespace NUnit.Runner.TestListeners
             //Visual Studio and causes tests to get all whacked up. 
             //This is a fix for dotnet-test-nunit#58
             string uniqueName = xml.Attribute("id").ToString() + _assemblyPath;
-            Guid testSignature = uniqueName.ConvertToGuid();
+            Guid testSignature = uniqueName.GetSignatureAsGuid();
 
             var test = new Test
             {

--- a/src/dotnet-test-nunit/TestListeners/BaseTestListener.cs
+++ b/src/dotnet-test-nunit/TestListeners/BaseTestListener.cs
@@ -57,23 +57,20 @@ namespace NUnit.Runner.TestListeners
             var methodName = xml.Attribute("methodname")?.Value;
             var sourceData = _provider?.GetSourceData(className, methodName);
 
-            //if we have a "fullname" then use it to generate 
-            //a unique identifier for the test otherwise, use 
-            //the id to generate a unique id.  The id from the 
+            //use the _assemblyPath plus the Id attribute to
+            //generate a unique signature for this test.
+            //Before, just the id was used, but the id from the 
             //xml attribute is not sufficient, because different 
             //projects in the same solution will generate the same
             //id.  In "Design" mode, this causes a conflict within 
             //Visual Studio and causes tests to get all whacked up. 
             //This is a fix for dotnet-test-nunit#58
-            Guid uniqueId;
-            if (xml.Attribute("fullname") != null)
-                uniqueId = xml.Attribute("fullname").Value.ConvertToGuid();
-            else
-                uniqueId = xml.Attribute("id").ConvertToGuid();
+            string uniqueName = xml.Attribute("id").ToString() + _assemblyPath;
+            Guid testSignature = uniqueName.ConvertToGuid();
 
             var test = new Test
             {
-                Id = uniqueId,
+                Id = testSignature,
                 DisplayName = xml.Attribute("name")?.Value ?? "",
                 FullyQualifiedName = xml.Attribute("fullname")?.Value ?? "",
                 CodeFilePath = sourceData?.Filename,


### PR DESCRIPTION
These changes are a proposed fix for issue #58 

Visual studio runs the test discovery process for each project in the solution.  During each run, the "Id" attribute on the Xml node for the test starts at 1001.  Therefore, the Ids for all tests in a solution are not unique (since the id for the first test in each project will be 1001). 

The changes in this pull request use the fullname attribute to generate a Guid.  Because the fullname includes the entire namespace of the class (plus the method), I think this would be sufficient to generate a unique Guid.  If for some reason the fullname is not available on the test, it falls back to using the "Id" attribute to generate the Guid.

Fixes #58 
Fixes #76 
Fixes #80