### PR TITLE
Fix for issue #87

### DIFF
--- a/src/dotnet-test-nunit/TestListeners/BaseTestListener.cs
+++ b/src/dotnet-test-nunit/TestListeners/BaseTestListener.cs
@@ -77,7 +77,7 @@ namespace NUnit.Runner.TestListeners
             //test ID, then visual Studio will ignore the new 
             //FullyQualifiedName returned during test discovery.  
             //While it ignores the new FullyQualifiedName, it will
-            //update the DisplayName, which made degugging this
+            //update the DisplayName, which made debugging this
             //very frustrating.  Nonetheless, to force a new
             //guid, we use the fullname of the testcase in the 
             //Guid/signature generation.

--- a/src/dotnet-test-nunit/TestListeners/BaseTestListener.cs
+++ b/src/dotnet-test-nunit/TestListeners/BaseTestListener.cs
@@ -57,15 +57,35 @@ namespace NUnit.Runner.TestListeners
             var methodName = xml.Attribute("methodname")?.Value;
             var sourceData = _provider?.GetSourceData(className, methodName);
 
-            //use the _assemblyPath plus the Id attribute to
-            //generate a unique signature for this test.
-            //Before, just the id was used, but the id from the 
+            //use the _assemblyPath, the test case Id attribute,
+            //and the fullName attribute to generate a unique signature 
+            //for this test.
+            //
+            //Originally, just the id was used, but the id from the 
             //xml attribute is not sufficient, because different 
             //projects in the same solution will generate the same
             //id.  In "Design" mode, this causes a conflict within 
             //Visual Studio and causes tests to get all whacked up. 
             //This is a fix for dotnet-test-nunit#58
-            string uniqueName = xml.Attribute("id").ToString() + _assemblyPath;
+            //
+            //However, another issue was discovered (dotnet-test-nunit#87)
+            //Turns out, the assembly name and test id is also not sufficient.
+            //During the discovery process, Visual Studio will not
+            //update the internal value for FulluyQualifiedName for
+            //a test if the Guid does not change.  Therefore, if you
+            //change the values of a TestCase, and they have the same
+            //test ID, then visual Studio will ignore the new 
+            //FullyQualifiedName returned during test discovery.  
+            //While it ignores the new FullyQualifiedName, it will
+            //update the DisplayName, which made degugging this
+            //very frustrating.  Nonetheless, to force a new
+            //guid, we use the fullname of the testcase in the 
+            //Guid/signature generation.
+            string uniqueName = xml.Attribute("id") 
+                + "|" 
+                + _assemblyPath 
+                + "|" 
+                + xml.Attribute("fullname")?.Value ?? "";
             Guid testSignature = uniqueName.GetSignatureAsGuid();
 
             var test = new Test


### PR DESCRIPTION
A fix for Issue #87 

Turns out, the assembly name and test id is also not sufficient for the generation of a Guid for a test case. During the discovery process, Visual Studio will not update the internal value for FulluyQualifiedName for a test if the Guid does not change. Therefore, if you change the values of a TestCase (or the name of a test), and they have the same test IDs across runs, then visual Studio will ignore the new FullyQualifiedName returned during test discovery since the Guid doesn't change.

While it ignores the new FullyQualifiedName, it will update the DisplayName, which made debugging this very frustrating. Nonetheless, to force a new Guid, we use the fullname of the testcase in the Guid/signature generation and that seems to solve the problem.

The following comment (from the xunit project) does a great job laying out the requirements

> The unique identifier for a test case should be able to discriminate
> among test cases, even those which are varied invocations against the
> same test method (i.e., theories). Ideally, this identifier would remain
> stable until such time as the developer changes some fundamental part
> of the identity (assembly, class name, test name, or test data); however,
> the minimum stability of the identifier must at least extend across
> multiple discoveries of the same test in the same (non-recompiled)
> assembly.

This fix uses the assembly name plus the test case id plus the fully qualified name of the test to generate a Guid. By using all three of these values as the input to Guid generation, we should be able to meet the requirements laid out in the comment above.