### PR TITLE
Updated Microsoft.Extensions.DependencyModel to 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: csharp
 
 addons:
   apt:
@@ -10,54 +10,24 @@ addons:
     - libunwind8
     - zlib1g
 
-matrix:
-  include:
-    - os: linux
-      dist: trusty # Ubuntu 14.04
-      sudo: required
-      env: CONFIGURATION=Debug
-    - os: linux
-      dist: trusty
-      sudo: required
-      env: CONFIGURATION=Release
-    - os: osx
-      osx_image: xcode7.2 # macOS 10.11
-      env: CONFIGURATION=Debug
-    - os: osx
-      osx_image: xcode7.2
-      env: CONFIGURATION=Release
+sudo: required
+os:
+  - linux
+  - osx
+dist: trusty # Ubuntu 14.04
 
-before_install:
-  # Install OpenSSL
-  - if test "$TRAVIS_OS_NAME" == "osx"; then
-      brew install openssl;
-      brew link --force openssl;
-      export DOTNET_SDK_URL="https://go.microsoft.com/fwlink/?LinkID=809128";
-    else
-      export DOTNET_SDK_URL="https://go.microsoft.com/fwlink/?LinkID=809129";
-    fi
-
-  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
-
-  # Install .NET CLI
-  - mkdir $DOTNET_INSTALL_DIR
-  - curl -L $DOTNET_SDK_URL -o dotnet_package
-  - tar -xvzf dotnet_package -C $DOTNET_INSTALL_DIR
-
-  # Add dotnet to PATH
-  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
+mono: none
+dotnet: 1.0.0-preview2-003121
+env:
+  global:
+    - DOTNETCORE=1
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+    - DOTNET_CLI_TELEMETRY_OPTOUT=true
+  matrix:
+    - CONFIGURATION=Debug
+    - CONFIGURATION=Release
 
 install:
-  # Display dotnet version info
-  - which dotnet;
-    if [ $? -eq 0 ]; then
-      echo "Using dotnet:";
-      dotnet --info;
-    else
-      echo "dotnet.exe not found"
-      exit 1;
-    fi
-
   # [WORKAROUND]
   #
   # SYNOPSIS:
@@ -110,6 +80,7 @@ install:
       nvm install stable && nvm use stable;
     fi
   - node -e "jsonPath='./test/dotnet-test-nunit.test.runner/project.json';data=require(jsonPath);fs=require('fs');delete data.frameworks.net451;fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2))"
+
 
   # Restore dependencies
   - dotnet restore

--- a/src/dotnet-test-nunit/TestRunner.cs
+++ b/src/dotnet-test-nunit/TestRunner.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Extensions.Testing.Abstractions;
 using Newtonsoft.Json;
 using NUnit.Engine;

--- a/src/dotnet-test-nunit/project.json
+++ b/src/dotnet-test-nunit/project.json
@@ -24,7 +24,8 @@
 
   "dependencies": {
     "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview2-003121",
-    "Microsoft.Extensions.DependencyModel": "1.0.0",
+    "Microsoft.DotNet.PlatformAbstractions": "1.1.0",
+    "Microsoft.Extensions.DependencyModel": "1.1.0",
     "NUnit.Portable.Agent": "3.4.0-beta-3",
     "NUnit.Result.Writer.V2": "1.0.0"
   },


### PR DESCRIPTION
In order to avoid a warning when using nunit in VS 2017 RC: "Found conflicts between different versions of the same dependent assembly that could not be resolved"
This is basically the same issue that was in xunit: https://github.com/xunit/xunit/issues/1091